### PR TITLE
Improve UI and add crypto API stubs

### DIFF
--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get('symbol');
+
+  return NextResponse.json(
+    { symbol, price: null, message: 'Price lookup not implemented' },
+    { status: 501 }
+  );
+}

--- a/app/api/wallet/connect/route.ts
+++ b/app/api/wallet/connect/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json(
+    { message: 'Wallet connection not implemented' },
+    { status: 501 }
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,3 +17,30 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 1s ease forwards;
+}
+
+.fade-in-up {
+  opacity: 0;
+  animation: fadeInUp 0.8s ease forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,45 +1,79 @@
+'use client';
+
+import { useState } from "react";
+
 export default function Home() {
+  const [symbol, setSymbol] = useState("");
+  const [price, setPrice] = useState<number | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
   const features = [
     {
       title: "On-chain Registry",
-      description: "Track asset ownership using immutable smart contracts."
+      description: "Track asset ownership using immutable smart contracts.",
     },
     {
       title: "Compliance Ready",
-      description: "Integrated KYC/AML modules keep your platform aligned with regulations."
+      description:
+        "Integrated KYC/AML modules keep your platform aligned with regulations.",
     },
     {
       title: "Real-time Settlement",
-      description: "Experience instant settlement with blockchain finality."
-    }
+      description:
+        "Experience instant settlement with blockchain finality.",
+    },
   ];
+
+  const connectWallet = async () => {
+    setConnecting(true);
+    await fetch("/api/wallet/connect", { method: "POST" });
+    setConnecting(false);
+  };
+
+  const fetchPrice = async () => {
+    const res = await fetch(`/api/prices?symbol=${symbol}`);
+    const data = await res.json();
+    setPrice(data.price);
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-950 via-black to-slate-900 text-gray-100">
-      <header className="max-w-6xl mx-auto flex justify-between items-center p-6">
+      <header className="max-w-6xl mx-auto flex items-center justify-between p-6">
         <h1 className="text-2xl font-bold">Winrock RWA</h1>
         <nav className="flex gap-6 text-sm">
-          <a href="#features" className="hover:text-indigo-400">
+          <a href="#features" className="hover:text-indigo-400 transition-colors">
             Features
           </a>
-          <a href="#docs" className="hover:text-indigo-400">
+          <a href="#docs" className="hover:text-indigo-400 transition-colors">
             Docs
           </a>
-          <a href="#community" className="hover:text-indigo-400">
+          <a href="#community" className="hover:text-indigo-400 transition-colors">
             Community
           </a>
         </nav>
+        <button
+          onClick={connectWallet}
+          className="ml-6 px-4 py-2 text-sm rounded-md bg-indigo-600 hover:bg-indigo-500 transition-all"
+        >
+          {connecting ? "Connecting..." : "Connect Wallet"}
+        </button>
       </header>
 
       <main className="max-w-6xl mx-auto px-6">
         <section className="py-24 text-center">
-          <h2 className="text-5xl font-extrabold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-indigo-400 to-fuchsia-500">
+          <h2 className="fade-in-up text-5xl font-extrabold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-indigo-400 to-fuchsia-500">
             Tokenize Real World Assets
           </h2>
-          <p className="text-lg text-indigo-100/80 max-w-2xl mx-auto mb-10">
+          <p
+            className="fade-in-up text-lg text-indigo-100/80 max-w-2xl mx-auto mb-10"
+            style={{ animationDelay: "0.2s" }}
+          >
             Build, issue, and trade tokenized assets with a modern blockchain interface.
           </p>
-          <div className="flex justify-center gap-4">
+          <div
+            className="fade-in-up flex justify-center gap-4"
+            style={{ animationDelay: "0.4s" }}
+          >
             <a
               className="px-8 py-3 rounded-lg bg-indigo-600 hover:bg-indigo-500 transition-colors"
               href="#start"
@@ -56,15 +90,37 @@ export default function Home() {
         </section>
 
         <section id="features" className="grid gap-8 sm:grid-cols-3 pb-24">
-          {features.map((feature) => (
+          {features.map((feature, idx) => (
             <div
               key={feature.title}
-              className="p-6 bg-white/5 rounded-xl backdrop-blur border border-white/10"
+              className="fade-in-up p-6 bg-white/5 rounded-xl backdrop-blur border border-white/10 transform transition-transform hover:-translate-y-1 hover:shadow-xl"
+              style={{ animationDelay: `${idx * 0.1 + 0.2}s` }}
             >
               <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
               <p className="text-sm text-indigo-100/80">{feature.description}</p>
             </div>
           ))}
+        </section>
+
+        <section id="price" className="pb-24 text-center fade-in-up" style={{ animationDelay: "0.2s" }}>
+          <h3 className="text-3xl font-bold mb-4">Check Crypto Price</h3>
+          <div className="flex justify-center gap-2">
+            <input
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              placeholder="e.g. BTC"
+              className="px-4 py-2 rounded-md bg-white/10 border border-white/20 focus:outline-none"
+            />
+            <button
+              onClick={fetchPrice}
+              className="px-4 py-2 rounded-md bg-indigo-600 hover:bg-indigo-500 transition-colors"
+            >
+              Query
+            </button>
+          </div>
+          {price !== null && (
+            <p className="mt-4 text-lg">Current price: {price}</p>
+          )}
         </section>
       </main>
 


### PR DESCRIPTION
## Summary
- Add fade-in animations for smoother visual presentation
- Enhance home page with wallet connection button and price checker UI
- Stub API routes for wallet connections and crypto price lookups

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bf84fcbfe08323886166daa91e62a9