### PR TITLE
Display top 100 crypto markets with candlestick charts

### DIFF
--- a/app/components/CandlestickChart.tsx
+++ b/app/components/CandlestickChart.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+interface CandlestickChartProps {
+  data: number[][]; // [timestamp, open, high, low, close]
+}
+
+export default function CandlestickChart({ data }: CandlestickChartProps) {
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  const width = 200;
+  const height = 100;
+  const candleWidth = width / data.length;
+  const highs = data.map((d) => d[2]);
+  const lows = data.map((d) => d[3]);
+  const max = Math.max(...highs);
+  const min = Math.min(...lows);
+  const scaleY = (price: number) => ((max - price) / (max - min)) * height;
+
+  return (
+    <svg width={width} height={height}>
+      {data.map((d, i) => {
+        const [time, open, high, low, close] = d;
+        const x = i * candleWidth + candleWidth / 2;
+        const color = close >= open ? '#16a34a' : '#dc2626';
+        const yHigh = scaleY(high);
+        const yLow = scaleY(low);
+        const yOpen = scaleY(open);
+        const yClose = scaleY(close);
+        const rectY = Math.min(yOpen, yClose);
+        const rectHeight = Math.max(1, Math.abs(yClose - yOpen));
+
+        return (
+          <g key={time}>
+            <line x1={x} x2={x} y1={yHigh} y2={yLow} stroke={color} strokeWidth={1} />
+            <rect
+              x={x - candleWidth / 2 + 1}
+              y={rectY}
+              width={candleWidth - 2}
+              height={rectHeight}
+              fill={color}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+

--- a/app/launchapp/page.tsx
+++ b/app/launchapp/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CandlestickChart from '../components/CandlestickChart';
+
+interface MarketCoin {
+  id: string;
+  name: string;
+  symbol: string;
+  market_cap: number;
+  image: string;
+}
+
+interface Coin extends MarketCoin {
+  ohlc: number[][];
+}
+
+export default function LaunchAppPage() {
+  const [coins, setCoins] = useState<Coin[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch(
+          'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=100&page=1&sparkline=false'
+        );
+        const marketData: MarketCoin[] = await res.json();
+        const coinsWithOhlc: Coin[] = await Promise.all(
+          marketData.map(async (coin: MarketCoin) => {
+            const ohlcRes = await fetch(
+              `https://api.coingecko.com/api/v3/coins/${coin.id}/ohlc?vs_currency=usd&days=7`
+            );
+            const ohlcData = await ohlcRes.json();
+            return {
+              id: coin.id,
+              name: coin.name,
+              symbol: coin.symbol,
+              market_cap: coin.market_cap,
+              image: coin.image,
+              ohlc: ohlcData,
+            };
+          })
+        );
+        setCoins(coinsWithOhlc);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <p className="p-6">Loading...</p>;
+  }
+
+  return (
+    <div className="p-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {coins.map((coin) => (
+        <div key={coin.id} className="p-4 bg-white/5 rounded-lg border border-white/10">
+          <div className="flex items-center gap-2 mb-2">
+            <img src={coin.image} alt={coin.name} className="w-6 h-6" />
+            <h4 className="font-semibold">
+              {coin.name} ({coin.symbol.toUpperCase()})
+            </h4>
+          </div>
+          <CandlestickChart data={coin.ohlc} />
+          <p className="mt-2 text-sm">Market Cap: ${coin.market_cap.toLocaleString()}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,7 @@ export default function Home() {
           >
             <a
               className="px-8 py-3 rounded-lg bg-indigo-600 hover:bg-indigo-500 transition-colors"
-              href="#start"
+              href="/launchapp"
             >
               Launch App
             </a>


### PR DESCRIPTION
## Summary
- Link the homepage Launch App button to a new `/launchapp` route
- Fetch top-100 cryptocurrencies by market cap and render their OHLC data
- Introduce an SVG-based candlestick chart component to visualize price movements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bf94668d008323ba43adba480467e3