### PR TITLE
feat: show market overview after Launch App

### DIFF
--- a/app/components/SparklineChart.tsx
+++ b/app/components/SparklineChart.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+interface SparklineChartProps {
+  data: number[];
+}
+
+export default function SparklineChart({ data }: SparklineChartProps) {
+  if (!data || data.length === 0) {
+    return null;
+  }
+
+  const width = 100;
+  const height = 40;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const points = data
+    .map((p, i) => {
+      const x = (i / (data.length - 1)) * width;
+      const y = height - ((p - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={width} height={height}>
+      <polyline
+        fill="none"
+        stroke="#3b82f6"
+        strokeWidth="1"
+        points={points}
+      />
+    </svg>
+  );
+}
+

--- a/app/launchapp/page.tsx
+++ b/app/launchapp/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import CandlestickChart from '../components/CandlestickChart';
+import Image from 'next/image';
+import SparklineChart from '../components/SparklineChart';
 
-interface MarketCoin {
+interface Coin {
   id: string;
   name: string;
   symbol: string;
-  market_cap: number;
   image: string;
-}
-
-interface Coin extends MarketCoin {
-  ohlc: number[][];
+  current_price: number;
+  market_cap: number;
+  price_change_percentage_24h: number;
+  sparkline_in_7d: { price: number[] };
 }
 
 export default function LaunchAppPage() {
@@ -23,26 +23,10 @@ export default function LaunchAppPage() {
     const fetchData = async () => {
       try {
         const res = await fetch(
-          'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=100&page=1&sparkline=false'
+          'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=100&page=1&sparkline=true'
         );
-        const marketData: MarketCoin[] = await res.json();
-        const coinsWithOhlc: Coin[] = await Promise.all(
-          marketData.map(async (coin: MarketCoin) => {
-            const ohlcRes = await fetch(
-              `https://api.coingecko.com/api/v3/coins/${coin.id}/ohlc?vs_currency=usd&days=7`
-            );
-            const ohlcData = await ohlcRes.json();
-            return {
-              id: coin.id,
-              name: coin.name,
-              symbol: coin.symbol,
-              market_cap: coin.market_cap,
-              image: coin.image,
-              ohlc: ohlcData,
-            };
-          })
-        );
-        setCoins(coinsWithOhlc);
+        const data: Coin[] = await res.json();
+        setCoins(data);
       } catch (e) {
         console.error(e);
       } finally {
@@ -58,19 +42,55 @@ export default function LaunchAppPage() {
   }
 
   return (
-    <div className="p-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {coins.map((coin) => (
-        <div key={coin.id} className="p-4 bg-white/5 rounded-lg border border-white/10">
-          <div className="flex items-center gap-2 mb-2">
-            <img src={coin.image} alt={coin.name} className="w-6 h-6" />
-            <h4 className="font-semibold">
-              {coin.name} ({coin.symbol.toUpperCase()})
-            </h4>
-          </div>
-          <CandlestickChart data={coin.ohlc} />
-          <p className="mt-2 text-sm">Market Cap: ${coin.market_cap.toLocaleString()}</p>
-        </div>
-      ))}
+    <div className="p-6 overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="py-2 px-4">#</th>
+            <th className="py-2 px-4">Coin</th>
+            <th className="py-2 px-4">Price</th>
+            <th className="py-2 px-4">24h %</th>
+            <th className="py-2 px-4">Market Cap</th>
+            <th className="py-2 px-4">Last 7d</th>
+          </tr>
+        </thead>
+        <tbody>
+          {coins.map((coin, index) => (
+            <tr key={coin.id} className="border-t border-white/10">
+              <td className="py-2 px-4">{index + 1}</td>
+              <td className="py-2 px-4">
+                <div className="flex items-center">
+                  <Image
+                    src={coin.image}
+                    alt={coin.name}
+                    width={20}
+                    height={20}
+                    className="mr-2"
+                  />
+                  <span>{coin.name}</span>
+                  <span className="ml-2 text-xs text-white/50">
+                    {coin.symbol.toUpperCase()}
+                  </span>
+                </div>
+              </td>
+              <td className="py-2 px-4">${coin.current_price.toLocaleString()}</td>
+              <td
+                className={`py-2 px-4 ${
+                  coin.price_change_percentage_24h >= 0
+                    ? 'text-green-500'
+                    : 'text-red-500'
+                }`}
+              >
+                {coin.price_change_percentage_24h.toFixed(2)}%
+              </td>
+              <td className="py-2 px-4">${coin.market_cap.toLocaleString()}</td>
+              <td className="py-2 px-4">
+                <SparklineChart data={coin.sparkline_in_7d.price} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'assets.coingecko.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add sparkline component for mini 7d charts
- display top 100 market data in table on Launch App page
- fix overlapping coin text by spacing name and symbol
- show coin icons before each coin name
- allow loading remote coin images from CoinGecko
- prevent sparkline chart from dividing by zero when prices are flat

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bf9d8dbea08323b1e46df8ddf1e98d