### PR TITLE
Improve DPI handling for Chinese and English interfaces

### DIFF
--- a/app/LanguageContext.tsx
+++ b/app/LanguageContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
 
 type Lang = "en" | "zh";
 
@@ -91,6 +91,10 @@ const LanguageContext = createContext<LangContextProps | undefined>(undefined);
 
 export const LanguageProvider = ({ children }: { children: ReactNode }) => {
   const [lang, setLang] = useState<Lang>("en");
+  useEffect(() => {
+    // Keep the document language attribute in sync for language-specific styling
+    document.documentElement.lang = lang;
+  }, [lang]);
   const toggleLang = () => setLang((l) => (l === "en" ? "zh" : "en"));
   const t = (key: TranslationKey) => translations[lang][key];
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,3 +83,14 @@ body {
     transform: rotate(calc(var(--start) + 360deg));
   }
 }
+
+@media (min-resolution: 2dppx) {
+  /* Adjust base font sizes for crisp rendering on high-DPI displays */
+  html:lang(en) {
+    font-size: 16px;
+  }
+
+  html:lang(zh) {
+    font-size: 17px;
+  }
+}


### PR DESCRIPTION
## Summary
- sync document language attribute with current selection for language-specific styling
- add high-DPI font-size adjustments for English and Chinese

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c115401d848323be57e4014668da91